### PR TITLE
fixed clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 8-bit-computer-emulator
 
-This is a C++ based emulator of my [8-bit-computer](https://github.com/blurpy/8-bit-computer).
+This is a fork of a C++ based emulator of blurpy's [8-bit-computer](https://github.com/blurpy/8-bit-computer).
 
 The goal is to make the emulator as realistic as possible. It's based on emulating the communication between the different parts of the computer so the state is accurate on every cycle. This means the instruction decoder does not change state of memory or registers, but rather directs which part can communicate over the bus at different points in time, like the real hardware do with the microcode in the EEPROMs. Programs that run on the real hardware will run unmodified on the emulator with the same result.
 

--- a/src/core/Clock.h
+++ b/src/core/Clock.h
@@ -3,6 +3,7 @@
 
 #include <thread>
 #include <vector>
+#include <memory>
 
 #include "ClockListener.h"
 #include "ClockObserver.h"


### PR DESCRIPTION
I had a problem with building on 

> Debian GNU/Linux 12
> Kernel 6.1.0-11-amd64
> Xfce 4.18
> libc6:amd64 2.36-9+deb12u1
> libsdl2-2.0-0:amd64 2.26.5+dfsg-1
> libsdl2-ttf-2.0-0:amd64 2.20.1+dfsg-2

I just added `#include <memory>` into Clock.h and now it builds nicely. Thanks for the amazing emulator.